### PR TITLE
Yubchoi

### DIFF
--- a/src/block/block.controller.ts
+++ b/src/block/block.controller.ts
@@ -13,6 +13,7 @@ import { UserEntity } from 'src/user/user.entity';
 import { PositiveIntPipe } from 'src/common/pipes/positiveInt.pipe';
 import { GetUser } from 'src/auth/get-user.decostor';
 import { AuthGuard } from '@nestjs/passport';
+import { UserProfileDto } from 'src/user/user.dto';
 
 @Controller('block')
 @UseGuards(AuthGuard())
@@ -22,15 +23,13 @@ export class BlockController {
   private logger = new Logger(BlockController.name);
 
   @Get()
-  async getBlockList(
-    @GetUser('id', ParseIntPipe, PositiveIntPipe) userId: number,
-  ): Promise<UserEntity[]> {
-    return await this.blockService.getBlockListkByUserId(userId);
+  async getBlockList(@GetUser('id') userId: number): Promise<UserProfileDto[]> {
+    return await this.blockService.getBlockListByUserId(userId);
   }
 
   @Delete()
   async deleteBlock(
-    @GetUser('id', ParseIntPipe, PositiveIntPipe) userId: number,
+    @GetUser('id') userId: number,
     @Body('bannedUserId', ParseIntPipe, PositiveIntPipe) bannedUserId: number,
   ) {
     await this.blockService.deleteBlock({
@@ -41,7 +40,7 @@ export class BlockController {
 
   @Post()
   async createBlock(
-    @GetUser('id', ParseIntPipe, PositiveIntPipe) userId: number,
+    @GetUser('id') userId: number,
     @Body('bannedUserId', ParseIntPipe, PositiveIntPipe) bannedUserId: number,
   ) {
     return await this.blockService.createBlock({

--- a/src/block/block.controller.ts
+++ b/src/block/block.controller.ts
@@ -2,18 +2,15 @@ import {
   Body,
   Controller,
   Delete,
-  Get,
   Logger,
   Post,
   ParseIntPipe,
   UseGuards,
 } from '@nestjs/common';
 import { BlockService } from './block.service';
-import { UserEntity } from 'src/user/user.entity';
 import { PositiveIntPipe } from 'src/common/pipes/positiveInt.pipe';
 import { GetUser } from 'src/auth/get-user.decostor';
 import { AuthGuard } from '@nestjs/passport';
-import { UserProfileDto } from 'src/user/user.dto';
 
 @Controller('block')
 @UseGuards(AuthGuard())
@@ -22,10 +19,10 @@ export class BlockController {
 
   private logger = new Logger(BlockController.name);
 
-  @Get()
-  async getBlockList(@GetUser('id') userId: number): Promise<UserProfileDto[]> {
-    return await this.blockService.getBlockListByUserId(userId);
-  }
+  // @Get()
+  // async getBlockList(@GetUser('id') userId: number): Promise<UserProfileDto[]> {
+  //   return await this.blockService.getBlockListByFromId(userId);
+  // }
 
   @Delete()
   async deleteBlock(
@@ -43,6 +40,7 @@ export class BlockController {
     @GetUser('id') userId: number,
     @Body('bannedUserId', ParseIntPipe, PositiveIntPipe) bannedUserId: number,
   ) {
+    userId = 1;
     return await this.blockService.createBlock({
       from: userId,
       to: bannedUserId,

--- a/src/block/block.repository.ts
+++ b/src/block/block.repository.ts
@@ -35,13 +35,19 @@ export class BlockRepository extends Repository<BlockEntity> {
       throw new NotFoundException(`Block ${deleteBlockDto} not found`);
   }
 
-  async getBlockByFromId(from: number): Promise<{ id: number; to: number }[]> {
+  async getBlockListByFromId(
+    from: number,
+  ): Promise<{ id: number; to: number }[]> {
     return await this.find({
       where: { from },
       select: ['to'],
     });
   }
 
+  async isBlocked(from: number, to: number): Promise<boolean> {
+    const block = await this.findOne({ where: { from, to } });
+    return block ? true : false;
+  }
   // async getAllBlock(): Promise<BlockEntity[]> {
   //   return await this.find({ order: { id: 'DESC' } });
   // }

--- a/src/block/block.service.ts
+++ b/src/block/block.service.ts
@@ -3,7 +3,7 @@ import { BlockRepository } from './block.repository';
 import { BlockDto } from './block.dto';
 import { BlockEntity } from './block.entity';
 import { UserRepository } from 'src/user/user.repository';
-import { UserEntity } from 'src/user/user.entity';
+import { UserProfileDto } from 'src/user/user.dto';
 
 @Injectable()
 export class BlockService {
@@ -27,13 +27,17 @@ export class BlockService {
     await this.blockRepository.deleteBlock(deleteBlockDto);
   }
 
-  async getBlockListkByUserId(userId: number): Promise<UserEntity[]> {
-    const blockUserId = await this.blockRepository.getBlockByFromId(userId);
+  async getBlockListByUserId(userId: number): Promise<UserProfileDto[]> {
+    const blockList = await this.blockRepository.getBlockListByFromId(userId);
     const blockUser = [];
-    for (const id of blockUserId) {
+    for (const id of blockList) {
       blockUser.push(await this.userRepository.getUserByUserId(id.to));
     }
     return blockUser;
+  }
+
+  async isBlocked(from: number, to: number): Promise<boolean> {
+    return await this.blockRepository.isBlocked(from, to);
   }
 
   // // TODO: 필요한가?

--- a/src/block/block.service.ts
+++ b/src/block/block.service.ts
@@ -4,6 +4,7 @@ import { BlockDto } from './block.dto';
 import { BlockEntity } from './block.entity';
 import { UserRepository } from 'src/user/user.repository';
 import { UserProfileDto } from 'src/user/user.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 @Injectable()
 export class BlockService {
@@ -27,17 +28,12 @@ export class BlockService {
     await this.blockRepository.deleteBlock(deleteBlockDto);
   }
 
-  async getBlockListByUserId(userId: number): Promise<UserProfileDto[]> {
-    const blockList = await this.blockRepository.getBlockListByFromId(userId);
-    const blockUser = [];
-    for (const id of blockList) {
-      blockUser.push(await this.userRepository.getUserByUserId(id.to));
-    }
-    return blockUser;
-  }
-
   async isBlocked(from: number, to: number): Promise<boolean> {
     return await this.blockRepository.isBlocked(from, to);
+  }
+
+  async getBlockListByFromId(id: number): Promise<{ to: number }[]> {
+    return await this.blockRepository.getBlockListByFromId(id);
   }
 
   // // TODO: 필요한가?

--- a/src/channel/channel.controller.ts
+++ b/src/channel/channel.controller.ts
@@ -22,7 +22,7 @@ export class ChannelController {
   @Post()
   @UseGuards(AuthGuard())
   async createChannel(
-    @GetUser('id', ParseIntPipe, PositiveIntPipe) userId: number,
+    @GetUser('id') userId: number,
     @Body('ChannelInfo', ChannelTypePipe) ChannelInfo: CreateChannelDto,
     @Body('ChannelUserInfo') ChannelUserInfo: CreateChanneUserDto[], // TODO: ChannelUserId만 받으면 안되나여?
   ) {
@@ -34,7 +34,7 @@ export class ChannelController {
   @Post('/join')
   @UseGuards(AuthGuard())
   async joinChannel(
-    @GetUser('id', ParseIntPipe, PositiveIntPipe) userId: number,
+    @GetUser('id') userId: number,
     @Body() createChannelUserDto: CreateChanneUserDto,
   ) {
     const { channelId } = createChannelUserDto;
@@ -54,9 +54,7 @@ export class ChannelController {
 
   @Get()
   @UseGuards(AuthGuard())
-  async getChannels(
-    @GetUser('id', ParseIntPipe, PositiveIntPipe) userId: number,
-  ) {
+  async getChannels(@GetUser('id') userId: number) {
     return this.chatService.getChannelByUserId(userId);
   }
 }

--- a/src/common/tranfrom.interceptor.ts
+++ b/src/common/tranfrom.interceptor.ts
@@ -3,6 +3,7 @@ import {
   NestInterceptor,
   ExecutionContext,
   CallHandler,
+  HttpStatus,
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -21,6 +22,7 @@ export class TransformInterceptor<T>
   ): Observable<Response<T>> {
     return next.handle().pipe(
       map((data) => ({
+        status: HttpStatus.OK,
         success: true,
         data,
       })),

--- a/src/friend/friend.controller.ts
+++ b/src/friend/friend.controller.ts
@@ -13,6 +13,7 @@ import { PositiveIntPipe } from 'src/common/pipes/positiveInt.pipe';
 import { UserEntity } from 'src/user/user.entity';
 import { AuthGuard } from '@nestjs/passport';
 import { GetUser } from 'src/auth/get-user.decostor';
+import { UserProfileDto } from 'src/user/user.dto';
 
 @Controller('friend')
 @UseGuards(AuthGuard())
@@ -23,14 +24,14 @@ export class FriendController {
 
   @Get()
   async getFriendList(
-    @GetUser('id', ParseIntPipe, PositiveIntPipe) userId: number,
-  ): Promise<UserEntity[]> {
+    @GetUser('id') userId: number,
+  ): Promise<UserProfileDto[]> {
     return await this.friendService.getFriendListByUserId(userId);
   }
 
   @Delete()
   async deleteFriend(
-    @GetUser('id', ParseIntPipe, PositiveIntPipe) userId: number,
+    @GetUser('id') userId: number,
     @Body('followingUserId', ParseIntPipe, PositiveIntPipe)
     followingUserId: number,
   ) {
@@ -42,7 +43,7 @@ export class FriendController {
 
   @Post()
   async createFriend(
-    @GetUser('id', ParseIntPipe, PositiveIntPipe) userId: number,
+    @GetUser('id') userId: number,
     @Body('followingUserId', ParseIntPipe, PositiveIntPipe)
     followingUserId: number,
   ) {

--- a/src/friend/friend.controller.ts
+++ b/src/friend/friend.controller.ts
@@ -22,12 +22,12 @@ export class FriendController {
 
   private logger = new Logger(FriendController.name);
 
-  @Get()
-  async getFriendList(
-    @GetUser('id') userId: number,
-  ): Promise<UserProfileDto[]> {
-    return await this.friendService.getFriendListByUserId(userId);
-  }
+  // @Get()
+  // async getFriendList(
+  //   @GetUser('id') userId: number,
+  // ): Promise<UserProfileDto[]> {
+  //   return await this.friendService.getFriendListByUserId(userId);
+  // }
 
   @Delete()
   async deleteFriend(

--- a/src/friend/friend.respository.ts
+++ b/src/friend/friend.respository.ts
@@ -29,7 +29,7 @@ export class FriendRepository extends Repository<FriendEntity> {
     return friend;
   }
 
-  async getFriendByFromId(id: number): Promise<{ to: number }[]> {
+  async getFriendListByFromId(id: number): Promise<{ to: number }[]> {
     return await this.find({
       where: { from: id },
       select: ['to'],
@@ -37,7 +37,7 @@ export class FriendRepository extends Repository<FriendEntity> {
     });
   }
 
-  async getFriendByToId(id: number): Promise<{ from: number }[]> {
+  async getFriendListByToId(id: number): Promise<{ from: number }[]> {
     return await this.find({
       where: { to: id },
       select: ['from'],
@@ -45,9 +45,15 @@ export class FriendRepository extends Repository<FriendEntity> {
     });
   }
 
-  async deleteFriend(deleteFriendDto: FriendDto): Promise<void> {
+  async deleteFriend(deleteFriendDto: FriendDto) {
     const result = await this.delete(deleteFriendDto);
     if (result.affected === 0)
       throw new ConflictException(`Friend ${deleteFriendDto} not found`);
+  }
+
+  async isFriend(from: number, to: number): Promise<boolean> {
+    const friend = await this.findOne({ where: { from, to } });
+    if (friend) return true;
+    else return false;
   }
 }

--- a/src/friend/friend.service.ts
+++ b/src/friend/friend.service.ts
@@ -3,7 +3,7 @@ import { FriendEntity } from './friend.entity';
 import { FriendRepository } from './friend.respository';
 import { UserRepository } from 'src/user/user.repository';
 import { FriendDto } from './friend.dto';
-import { UserEntity } from 'src/user/user.entity';
+import { UserProfileDto } from 'src/user/user.dto';
 
 @Injectable()
 export class FriendService {
@@ -25,24 +25,20 @@ export class FriendService {
     return await this.friendRepository.createFriend(createFriendDto);
   }
 
-  async getFriendByFromId(id: number): Promise<{ to: number }[]> {
-    return await this.friendRepository.getFriendByFromId(id);
+  async getFriendListByFromId(id: number): Promise<{ to: number }[]> {
+    return await this.friendRepository.getFriendListByFromId(id);
   }
 
-  async getFriendByToId(id: number): Promise<{ from: number }[]> {
-    return await this.friendRepository.getFriendByToId(id);
-  }
-
-  async getFriendListByUserId(userId: number): Promise<UserEntity[]> {
-    const friendId = await this.getFriendByFromId(userId);
-    const friends = [];
-    for (const id of friendId) {
-      friends.push(await this.userRepository.getUserByUserId(id.to));
-    }
-    return friends;
+  async getFriendListByToId(id: number): Promise<{ from: number }[]> {
+    return await this.friendRepository.getFriendListByToId(id);
   }
 
   async deleteFriend(createFriendDto: FriendDto) {
     await this.friendRepository.deleteFriend(createFriendDto);
+  }
+
+  async isFriend(from: number, to: number): Promise<boolean> {
+    const friend = await this.friendRepository.findOneBy({ from, to });
+    return friend ? true : false;
   }
 }

--- a/src/user/user.dto.ts
+++ b/src/user/user.dto.ts
@@ -1,5 +1,6 @@
 import { PickType } from '@nestjs/swagger';
 import { UserEntity } from './user.entity';
+import { IsBoolean } from 'class-validator';
 
 export class CreateUserDto extends PickType(UserEntity, [
   'nickname',
@@ -7,3 +8,20 @@ export class CreateUserDto extends PickType(UserEntity, [
   'ftId',
   'token',
 ] as const) {}
+
+export class UserProfileDto extends PickType(UserEntity, [
+  'id',
+  'nickname',
+  'avatar',
+  'winScore',
+  'loseScore',
+  'userState',
+  'winnerGame',
+  'loserGame',
+] as const) {
+  @IsBoolean()
+  isFriend: boolean;
+
+  @IsBoolean()
+  isBlocked: boolean;
+}

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -47,10 +47,10 @@ export class UserEntity extends CommonEntity {
   // @Exclude()
   token: string;
 
-  @OneToMany(() => GameEntity, (game) => game.winner)
+  @OneToMany(() => GameEntity, (game) => game.winner, { eager: true })
   winnerGame: GameEntity[];
 
-  @OneToMany(() => GameEntity, (game) => game.loser)
+  @OneToMany(() => GameEntity, (game) => game.loser, { eager: true })
   loserGame: GameEntity[];
 
   @Column({ nullable: true })

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -1,6 +1,5 @@
 import { Exclude } from 'class-transformer';
 import { IsEmail, IsIn, IsNumber, IsString } from 'class-validator';
-import { ChannelEntity } from 'src/channel/channel.entity';
 import { CommonEntity } from 'src/common/common.entity';
 import { GameEntity } from 'src/game/game.entity';
 import { Column, Entity, OneToMany, Unique } from 'typeorm';
@@ -20,7 +19,7 @@ export class UserEntity extends CommonEntity {
   ftId: string;
 
   @Column()
-  //@IsString()
+  @IsString()
   nickname: string;
 
   @Column({ default: 0 })
@@ -55,11 +54,13 @@ export class UserEntity extends CommonEntity {
   loserGame: GameEntity[];
 
   @Column({ nullable: true })
-  @Exclude()
+  // @Exclude()
+  @IsString()
   accessToken: string;
 
   @Column({ nullable: true })
-  @Exclude()
+  // @Exclude()
+  @IsString()
   refreshToken: string;
   //@OneToMany(() => ChannelUserEntity, (channelUser)=>channelUser.user)
   //Join :

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -27,7 +27,7 @@ export class UserService {
         HttpStatus.BAD_REQUEST,
       );
     user['friends'] = await this.getFriendListByUserId(userId);
-    user['blocks'] = await this.blockService.getBlockListByUserId(userId);
+    user['blocks'] = await this.getBlockListByUserId(userId);
     user['channels'] = await this.channelService.getChannelByUserId(userId);
     user.accessToken = undefined;
     user.refreshToken = undefined;
@@ -81,6 +81,15 @@ export class UserService {
       friends.push(await this.getUserProfileById(id.to));
     }
     return friends;
+  }
+
+  async getBlockListByUserId(userId: number): Promise<UserProfileDto[]> {
+    const blockList = await this.blockService.getBlockListByFromId(userId);
+    const blockUser = [];
+    for (const id of blockList) {
+      blockUser.push(await this.getUserProfileById(id.to));
+    }
+    return blockUser;
   }
 
   async createUser(createUserDto: CreateUserDto): Promise<UserEntity> {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -3,8 +3,7 @@ import { UserRepository } from './user.repository';
 import { UserEntity } from './user.entity';
 import { BlockService } from 'src/block/block.service';
 import { FriendService } from 'src/friend/friend.service';
-import { CreateUserDto } from './user.dto';
-import { FriendDto } from 'src/friend/friend.dto';
+import { CreateUserDto, UserProfileDto } from './user.dto';
 import { ChannelService } from 'src/channel/channel.service';
 
 @Injectable()
@@ -27,27 +26,61 @@ export class UserService {
         { message: `User with id ${userId} not found` },
         HttpStatus.BAD_REQUEST,
       );
-    user['friends'] = await this.friendService.getFriendListByUserId(userId);
-    user['blocks'] = await this.blockService.getBlockListkByUserId(userId);
+    user['friends'] = await this.getFriendListByUserId(userId);
+    user['blocks'] = await this.blockService.getBlockListByUserId(userId);
     user['channels'] = await this.channelService.getChannelByUserId(userId);
     user.accessToken = undefined;
     user.refreshToken = undefined;
     return user;
   }
 
-  async getUserByNickname(nickname: string): Promise<UserEntity> {
+  // async getUserByNickname(nickname: string): Promise<UserEntity> {
+  //   const user = await this.userRepository.getUserByNickname(nickname);
+  //   if (!user)
+  //     throw new HttpException(
+  //       { message: `User with nickname ${nickname} not found` },
+  //       HttpStatus.BAD_REQUEST,
+  //     );
+  //   /* 필요한가여?
+  //   user['friends'] = await this.friendService.getFriendListByUserId(user.id);
+  //   user['blocks'] = await this.blockService.getBlockListkByUserId(user.id);
+  //   user['channels'] = await this.channelService.getChannelByUserId(user.id);
+  //   */
+  //   user.accessToken = undefined;
+  //   user.refreshToken = undefined;
+  //   return user;
+  // }
+
+  async getUserProfileByNickname(
+    userId: number,
+    nickname: string,
+  ): Promise<UserProfileDto> {
     const user = await this.userRepository.getUserByNickname(nickname);
     if (!user)
       throw new HttpException(
         { message: `User with nickname ${nickname} not found` },
         HttpStatus.BAD_REQUEST,
       );
-    user['friends'] = await this.friendService.getFriendListByUserId(user.id);
-    user['blocks'] = await this.blockService.getBlockListkByUserId(user.id);
-    user['channels'] = await this.channelService.getChannelByUserId(user.id);
-    user.accessToken = undefined;
-    user.refreshToken = undefined;
-    return user;
+    return await this.convertUserEntityToDto(userId, user);
+  }
+
+  async getUserProfileById(userId: number): Promise<UserProfileDto> {
+    const user = await this.userRepository.getUserByUserId(userId);
+    if (!user)
+      throw new HttpException(
+        { message: `User with id ${userId} not found` },
+        HttpStatus.BAD_REQUEST,
+      );
+    return await this.convertUserEntityToDto(userId, user);
+  }
+
+  async getFriendListByUserId(userId: number): Promise<UserProfileDto[]> {
+    const friendList = await this.friendService.getFriendListByFromId(userId);
+    const friends = [];
+    for (const id of friendList) {
+      friends.push(await this.getUserProfileById(id.to));
+    }
+    return friends;
   }
 
   async createUser(createUserDto: CreateUserDto): Promise<UserEntity> {
@@ -58,20 +91,35 @@ export class UserService {
     this.userRepository.deleteUser(userId);
   }
 
-  async createFriend(createFriendDto: FriendDto) {
-    return this.friendService.creatFriend(createFriendDto);
-  }
-
-  async deleteFriend(createFriendDto: FriendDto) {
-    return this.friendService.deleteFriend(createFriendDto);
-  }
-
   async updateUserAcessToken(userId: number, accessToken: string) {
     return this.userRepository.updateUserAcessToken(userId, accessToken);
   }
 
   async updateUserReFreshToken(userId: number, refreshToken: string) {
     return this.userRepository.updateUserAcessToken(userId, refreshToken);
+  }
+
+  async convertUserEntityToDto(
+    fromId: number,
+    user: UserEntity,
+  ): Promise<UserProfileDto> {
+    const [isFriend, isBlocked] = await Promise.all([
+      this.friendService.isFriend(fromId, user.id),
+      this.blockService.isBlocked(fromId, user.id),
+    ]);
+    const userProfileDto: UserProfileDto = {
+      id: user.id,
+      nickname: user.nickname,
+      avatar: user.avatar,
+      winScore: user.winScore,
+      loseScore: user.loseScore,
+      userState: user.userState,
+      winnerGame: user.winnerGame,
+      loserGame: user.loserGame,
+      isFriend: isFriend,
+      isBlocked: isBlocked,
+    };
+    return userProfileDto;
   }
 
   //TODO: UserEntity Update


### PR DESCRIPTION
유저 검색 시 보여지는 FriendList, BlockList를 UserEntity[] 가 아닌 UserProfileDto[]로 바꾸려고 했으나
UserService와 FriendService, BlockService 간 무한 참조 현상이 발생합니다 . . . ^_ㅠ
1. FriendList와 BlockList를 UserService에서 가져오는 걸로 한다면 ? -> 모듈 구분이 정확하지 않은 느낌
2. 그냥 원래대로 UserEntity[]를 프론트에 넘겨주기 -> 불필요한 정보가 많아서 맘에 안들어요

일단 FriendList는 1번 방식으로 UserProfileDto[]를 넘겨주고 BlockList는 2번 방식으로 UserEntity[]를 넘겨주게 했는데요.
더 나은 방법에 대해 내일 여쭤보고 싶습니다!-!